### PR TITLE
Globalize `textarea` CSS and inherit global font

### DIFF
--- a/components/AddRemoveCollectionForm.js
+++ b/components/AddRemoveCollectionForm.js
@@ -46,9 +46,6 @@ export default function addRemoveCollectionForm({ errorMessage, onSubmit, collec
           width: 15px !important;
           margin-bottom: 10px;
         }
-        textarea {
-          resize: none;
-        }
         .error {
           color: brown;
           margin: 1rem 0 0;

--- a/components/CollectionCreateForm.js
+++ b/components/CollectionCreateForm.js
@@ -42,9 +42,6 @@ export default function CollectionCreateForm({ verified, errorMessage, onSubmit 
           width: 15px !important;
           margin-bottom: 10px;
         }
-        textarea {
-          resize: none;
-        }
         .error {
           color: brown;
           margin: 1rem 0 0;

--- a/components/CollectionEditForm.js
+++ b/components/CollectionEditForm.js
@@ -61,9 +61,6 @@ export default function CollectionEditForm({ verified, errorMessage, onSubmit, c
           width: 15px !important;
           margin-bottom: 10px;
         }
-        textarea {
-          resize: none;
-        }
         .error {
           color: brown;
           margin: 1rem 0 0;

--- a/components/CollectionShareForm.js
+++ b/components/CollectionShareForm.js
@@ -42,9 +42,6 @@ export default function CollectionShareForm({ errorMessage, onSubmit }) {
           width: 15px !important;
           margin-bottom: 10px;
         }
-        textarea {
-          resize: none;
-        }
         .error {
           color: brown;
           margin: 1rem 0 0;

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -83,6 +83,7 @@ export default function Layout({ children }) {
         textarea {
           resize: none;
           font-family: inherit;
+          font-size: 15px;
         }
 
         input {

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -80,6 +80,11 @@ export default function Layout({ children }) {
           color: #757575;
         }
 
+        textarea {
+          resize: none;
+          font-family: inherit;
+        }
+
         .list-hover {
           transition: filter 0.3s;
         }

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -84,6 +84,7 @@ export default function Layout({ children }) {
           resize: none;
           font-family: inherit;
           font-size: 15px;
+          letter-spacing: 0.1px;
         }
 
         input {

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -85,6 +85,10 @@ export default function Layout({ children }) {
           font-family: inherit;
         }
 
+        input {
+          font-family: inherit;
+        }
+
         .list-hover {
           transition: filter 0.3s;
         }

--- a/components/TaskCreateForm.js
+++ b/components/TaskCreateForm.js
@@ -44,9 +44,6 @@ export default function TaskCreateForm({ errorMessage, onSubmit }) {
           width: 15px !important;
           margin-bottom: 10px;
         }
-        textarea {
-          resize: none;
-        }
         .error {
           color: brown;
           margin: 1rem 0 0;

--- a/components/TaskEditForm.js
+++ b/components/TaskEditForm.js
@@ -75,9 +75,6 @@ export default function TaskEditForm({ errorMessage, onSubmit, task }) {
           width: 15px !important;
           margin-bottom: 10px;
         }
-        textarea {
-          resize: none;
-        }
         .error {
           color: brown;
           margin: 1rem 0 0;

--- a/components/UserAdminForm.js
+++ b/components/UserAdminForm.js
@@ -103,9 +103,6 @@ export default function UserAdminForm({ errorMessage, onSubmit, lookup }) {
           width: 15px !important;
           margin-bottom: 10px;
         }
-        textarea {
-          resize: none;
-        }
         .error {
           color: brown;
           margin: 1rem 0 0;

--- a/components/UserEditForm.js
+++ b/components/UserEditForm.js
@@ -77,9 +77,6 @@ export default function UserEditForm({ errorMessage, onSubmit, user }) {
           width: 15px !important;
           margin-bottom: 10px;
         }
-        textarea {
-          resize: none;
-        }
         .error {
           color: brown;
           margin: 1rem 0 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracktask",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracktask",
-  "version": "1.0.12",
+  "version": "1.1.12",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Fixes #145 by globalizing `textarea`'s CSS and allowing it to inherit the global `font-family`